### PR TITLE
Wii U GamePad support with libwiidrc

### DIFF
--- a/platform/wii/Makefile
+++ b/platform/wii/Makefile
@@ -40,7 +40,7 @@ LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lwiiuse -lbte -lvorbisidec -logg -lasnd -lfat -logc -lm
+LIBS	:=	-lwiiuse -lwiidrc -lbte -lvorbisidec -logg -lasnd -lfat -logc -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing


### PR DESCRIPTION
Hi again! Adding support for the Wii U GamePad, when running under a Wii VC environment, meaning the Wii U GamePad can be used to control the game. I duplicated the button (and left analog) layout you used for the Classic Controller, since the Wii U GamePad has the same button layout. Nice layout, by the way, love the Y/B action game arrangement.

I'm not sure if maybe you'd prefer not to make libwiidrc a requirement, since people just building for Wii don't get anything out of it, but I just felt it was neater to avoid fragmenting into separate Wii builds for Wii and Wii U.