### PR TITLE
Fix viXOrigin derp

### DIFF
--- a/platform/wii/source/graphics.cpp
+++ b/platform/wii/source/graphics.cpp
@@ -55,8 +55,10 @@ static void _setupVideo()
 		rmode->viWidth = 704;
 	} else
 	{
-		rmode->viWidth = (isWiiU)? 686: 640;
+		rmode->viWidth = 686;
 	}
+
+	rmode->viXOrigin = (VI_MAX_WIDTH_NTSC - rmode->viWidth)/2;
 
 	if (isWiiU)
 	{

--- a/platform/wii/source/input.cpp
+++ b/platform/wii/source/input.cpp
@@ -3,7 +3,6 @@
 #include "system.hpp"
 #include <gccore.h>
 #include <wiiuse/wpad.h>
-#include <string.h>
 #include <wiidrc/wiidrc.h>
 #include <math.h>
 


### PR DESCRIPTION
Big oops, I forgot to update the `viXOrigin` when changing the `viWidth` in my previous PR (#3). This corrects my mistake, so that the image is no longer off-center on Wii. Confirmed this has the correct behavior on both Wii (4:3 and 16:9) and Wii U.

Just for reference, `VI_MAX_WIDTH_NTSC` is always 720, it's kind of a useless variable. `VI_MAX_WIDTH_PAL` is the same, so there's no significance to using the NTSC/PAL versions or even just the integer `720`. I just went with the standard usage.

I also removed an unused `#include` I was using during testing from `input.cpp`. Double oops.