### PR TITLE
Fix projection on Wii; fixes #6

### DIFF
--- a/platform/wii/source/graphics.cpp
+++ b/platform/wii/source/graphics.cpp
@@ -138,9 +138,9 @@ static void _setupVideo()
 	GX_InvalidateTexAll();
 
 	if (widescreen)
-		guOrtho(perspective,0,479,0,854-1,0,300);
+		guOrtho(perspective,0,480,0,854,0,300);
 	else
-		guOrtho(perspective,0,479,0,639,0,300);
+		guOrtho(perspective,0,480,0,640,0,300);
 	
 	GX_LoadProjectionMtx(perspective, GX_ORTHOGRAPHIC);
 }


### PR DESCRIPTION
I asked around in #gc-forever on EFNet and it was explained by Extrems that the `guOrtho` projection is causing the scaling issues mentioned in #6. I don't know why 639/479 *aren't* correct, it seems sensible to me, but switching to 640/480 (and 854 for widescreen) appears to resolve this issue entirely.